### PR TITLE
RefET attribution code and example data

### DIFF
--- a/Attribution.for
+++ b/Attribution.for
@@ -1,0 +1,194 @@
+      PROGRAM ATTRIBUTION
+C     *******************
+C     Uses data derived from NLDAS-2 to calculate the depth contribution
+C     from each of the four ETrs driving variables to daily ETrs anomalies.
+
+C     Input data, from NLDAS datafiles:
+C       T_2m = 2-m daily air temperature [K]
+C       SWdn = surface downward shortwave radiation flux [W/m2]
+C       SpHm = 2-m specific humidity [kg/kg]
+C       U_2m = 2-m wind speed [m/sec]
+C       ETrs = daily reference ET [mm]
+
+C     Output:
+C       cont_[var] = mm contribution of each variable [var] to the
+C                    daily ETrs anomaly
+
+C     Author: Mike Hobbins
+C     Date: May 21, 2024
+
+      IMPLICIT  NONE
+      INTEGER   nrows,ncols,bnd_s,bnd_n,bnd_w,bnd_e,bnd_lo,bnd_hi,year,
+     +          mon,day,row,col,colin,rowin,i,var
+      REAL      Lat,Lon,Elev
+      CHARACTER varname(5)*4,root1*99,root2*99,specs*10,maskfile*99,
+     +          infile*99,outfile*99
+      DATA      varname/'T_2m','SWdn','SpHm','U_2m','ClEr'/
+
+C     Define nrows and ncols and root path.
+      PARAMETER (nrows  = 224,
+     +           ncols  = 464,
+     +           bnd_s  = 25,
+     +           bnd_n  = 53,
+     +           bnd_w  = -125,
+     +           bnd_e  = -67,
+     +           bnd_lo = -90,
+     +           bnd_hi = 4500,
+     +           root1  = '/Volumes/mhobbins_drobo/',
+     +           root2  = 'ETrc_attribution/CONUS/')
+
+      INTEGER    Mask(nrows,ncols)
+      REAL       ETrs_anom(nrows,ncols),sens(4,ncols),mean(4,ncols),
+     +           ts(4,ncols),cont(5,nrows,ncols),ETrs_mean(ncols),
+     +           ETrs(ncols)
+
+C     Read date from arguments
+      CALL get_command_argument(1,specs)
+      READ(specs,'(I4,2I2.2)') year,mon,day
+
+C     Read in geographic data to set mask for analysis
+      Mask = 0
+      WRITE(maskfile,'(A35,A31)') 
+     +      '/System/Volumes/Data/data/mhobbins/',
+     +      'mac159/scripts/gtopomean15k.asc'
+      OPEN(UNIT=9,FILE=maskfile,STATUS='OLD',ERR=99)
+      DO 10 row = nrows, 1, -1
+        DO col = 1, ncols
+C         - read input data: Col; Row; Lat [deg], latitude; Lon [deg],
+C         longitude; Elev [m], elevation
+          READ(9,*) colin,rowin,Lat,Lon,Elev
+C         Generate geographic analysis mask
+          IF((Lat.GT.bnd_s).AND.(Lat.LT.bnd_n).AND.
+     +       (Lon.GT.bnd_w).AND.(Lon.LT.bnd_e).AND.
+     +       (Elev.GT.bnd_lo).AND.(Elev.LT.bnd_hi))
+     +       Mask(row,col) = 1
+        ENDDO                                    ! end col loop
+10    ENDDO                                      ! end row loop
+      CLOSE(9)
+
+C     Initialize arrays
+      ETrs_anom = -9999.
+      sens      = -9999.
+      mean      = -9999.
+      ts        = -9999.
+      cont      = -9999.
+
+C     Estimate ETrs anomaly
+
+C     Open mean grid for ETrs
+      WRITE(infile,'(A24,A23,A17,2I2.2,A4)')
+     +      root1,root2,'7_day_climo/ETrs_',mon,day,'.asc'
+      OPEN(UNIT=10,FILE=infile,STATUS='OLD',ERR=99)
+C     Open time-series grid for ETrs
+      WRITE(infile,'(A24,A21,I4,2I2.2,A4)')
+     +      root1,'ETrc_data/daily/ETrs_',year,mon,day,'.asc'
+      OPEN(UNIT=11,FILE=infile,STATUS='OLD',ERR=99)
+C     Read mean and time-series grids
+      DO i = 1, 6                                ! skip file headers
+        READ(10,*)
+        READ(11,*)
+      ENDDO
+      DO 20 row = 1, nrows
+        READ(10,*) (ETrs_mean(col),col=1,ncols)
+        READ(11,*) (ETrs(col),col=1,ncols)
+        DO col = 1,ncols
+          IF((ETrs(col).GT.-9000.).AND.(ETrs_mean(col).GT.-9000.))
+     +      ETrs_anom(row,col) = ETrs(col) - ETrs_mean(col) 
+        ENDDO
+20    ENDDO
+      CLOSE(10)
+      CLOSE(11)
+
+C     Loop through all four ETrs-input variables {T_2m, SWdn, SpHm, U_2m}
+      DO 50 var = 1, 4
+
+C       Open variable sensitivity grids
+        WRITE(infile,'(A24,A23,A23,A4,A1,2I2.2,A4)')
+     +        root1,root2,'7_day_sensitivity/Sens_',
+     +        varname(var),'_',mon,day,'.asc'
+        OPEN(UNIT=12,FILE=infile,STATUS='OLD',ERR=99)
+C       Open variable mean grids
+        WRITE(infile,'(A24,A23,A12,A4,A1,2I2.2,A4)')
+     +        root1,root2,'7_day_climo/',
+     +        varname(var),'_',mon,day,'.asc'
+        OPEN(UNIT=13,FILE=infile,STATUS='OLD',ERR=99)
+C       Open variable time-series grids
+        WRITE(infile,'(A24,A20,A4,A1,I4,2I2.2,A4)')
+     +        root1,'NLDAS_drivers/daily/',
+     +        varname(var),'_',year,mon,day,'.asc'
+        OPEN(UNIT=14,FILE=infile,STATUS='OLD',ERR=99)
+
+C       Skip file headers
+        DO i = 1, 6
+          READ(12,*)
+          READ(13,*)
+          READ(14,*)
+        ENDDO
+
+C       Read sensitivity, mean, and time-series grids
+        DO 40 row = 1, nrows
+
+          READ(12,*) (sens(var,col),col=1,ncols)
+          READ(13,*) (mean(var,col),col=1,ncols)
+          READ(14,*) (ts(var,col),col=1,ncols)
+
+C         Estimate daily contribution to ETrs anomaly
+          DO 30 col = 1, ncols
+            IF((ts(var,col).GT.-9000.).AND.(mean(var,col).GT.-9000.)
+     +         .AND.(ETrs_anom(row,col).GT.-9000.)) THEN
+              cont(var,row,col) = (ts(var,col) - mean(var,col))
+     +                            * sens(var,col)
+              IF(var.eq.4) THEN                  ! calculate closure error
+                cont(5,row,col) = ETrs_anom(row,col) - (cont(1,row,col)
+     +                            + cont(2,row,col) + cont(3,row,col)
+     +                            + cont(4,row,col))
+              ENDIF
+            ENDIF
+
+30        ENDDO                                  ! end col loop
+
+40      ENDDO                                    ! end row loop
+
+        CLOSE(12)
+        CLOSE(13)
+        CLOSE(14)
+
+50    ENDDO                                      ! end var loop
+
+
+C     Output contribution depths for each driver and closure error
+      DO 60 var = 1, 5
+
+        WRITE(outfile,'(A24,A23,A19,A4,A1,I4,2I2.2,A4)')
+     +        root1,root2,'contributions/Cont_',
+     +        varname(var),'_',year,mon,day,'.asc'
+        OPEN(UNIT=15,FILE=outfile,STATUS='UNKNOWN',ERR=99)
+        WRITE(15,'(A6,I3)') 'ncols ',ncols
+        WRITE(15,'(A6,I3)') 'nrows ',nrows
+        WRITE(15,'(A14)') 'xllcorner -125'
+        WRITE(15,'(A12)') 'yllcorner 25'
+        WRITE(15,'(A14)') 'cellsize 0.125'
+        WRITE(15,'(A19)') 'nodata_value -9999.'
+        DO row = 1, nrows
+          WRITE(15,*) (cont(var,row,col),col=1,ncols)
+        ENDDO
+        CLOSE(15)
+
+60    ENDDO
+
+C     Output ETrs anomaly depth
+      WRITE(outfile,'(A24,A23,A24,I4,2I2.2,A4)')
+     +      root1,root2,'contributions/ETrs_anom_',year,mon,day,'.asc'
+      OPEN(UNIT=16,FILE=outfile,STATUS='UNKNOWN',ERR=99)
+      WRITE(16,'(A6,I3)') 'ncols ',ncols
+      WRITE(16,'(A6,I3)') 'nrows ',nrows
+      WRITE(16,'(A14)') 'xllcorner -125'
+      WRITE(16,'(A12)') 'yllcorner 25'
+      WRITE(16,'(A14)') 'cellsize 0.125'
+      WRITE(16,'(A19)') 'nodata_value -9999.'
+      DO row = 1, nrows
+        WRITE(16,*) (ETrs_anom(row,col),col=1,ncols)
+      ENDDO
+      CLOSE(16)
+
+99    END

--- a/ETrs_sensitivity_4_drivers.for
+++ b/ETrs_sensitivity_4_drivers.for
@@ -1,0 +1,354 @@
+      PROGRAM ETRS_SENSITIVITY_4_DRIVERS
+C     **********************************
+C     Uses 42-year climatological means of 7-day surfaces of North American
+C     Land Data Assimilation System phase-2 (NLDAS-2) drivers to generate
+C     surfaces of daily sensitivities of ETrs (simplified relative to the
+C     strict Penman-Monteith equation recommended by the ASCE-EWRI) to each
+C     of its drivers.
+
+C     ASCE-EWRI (2005), The ASCE Standardized Reference Evapotranspiration
+C       Equation, Task Committee on Standardization of Reference
+C       Evapotranspiration, Ed. Richard G. Allen.
+
+C     Input data:
+C       Elev = elevation [m]
+C       Lat  = latitude [degs]
+C     and 30-year means of the following input variables:
+C       T_2m = 2-m daily mean air temperature [K]
+C       SWdn = surface downward shortwave radiation flux [W/m2]
+C       SpHm = 2-m specific humidity [kg/kg]
+C       U_2m = 2-m wind speed [m/sec]
+
+C     Output data are the sensitivities of ETrs to the input variables:
+C       sens_T = to T_2m [(mm/day)/K]
+C       sens_R = to SWdn [(mm/day)/(W/m2)]
+C       sens_q = to SpHm [(mm/day)/(kg/kg)]
+C       sens_U = to U_2m [(mm/day)/(m/sec)]
+
+C     Notes:
+C     * all input variables in the main program are capitalized (not so in
+C         subroutine).
+C     * most parameters are in SI units; exceptions are Cn and ETrs [mm/day].
+C     * monlen array specifies a 29-day February, as sensitivities are needed
+C         for all days including February 29 in leap years.
+C     * jday array specifies a 28-day February as solar calculations need an
+C         accurate, integer Julian Day count, and most years have only 28 days
+C         in February.
+
+C     Author: Mike Hobbins
+C     Date: May 21, 2024
+
+
+      IMPLICIT  NONE
+      INTEGER   monlen(12),jday(12),nrows,ncols,bnd_s,bnd_n,bnd_w,bnd_e,
+     +          row,col,Colin,Rowin,mon,day,jdaysub,var,i,year,offset
+      REAL      bnd_lo,bnd_hi,Lon,pi
+      CHARACTER varname(4)*4,root*99,maskfile*99,outpath*99,outfile*99,
+     +          infile*99
+
+      DATA varname/'T_2m','SWdn','SpHm','U_2m'/
+      DATA monlen/31,29,31,30,31,30,31,31,30,31,30,31/
+      DATA jday/0,31,59,90,120,151,181,212,243,273,304,334/
+
+C     Define nrows [-] and ncols [-], geographic bounds of analysis, pi,
+C     and output path.
+      PARAMETER (nrows  = 224,
+     +           ncols  = 464,
+     +           bnd_s  = 25,
+     +           bnd_n  = 53,
+     +           bnd_w  = -125,
+     +           bnd_e  = -67,
+     +           bnd_lo = -90.,
+     +           bnd_hi = 4500.,
+     +           pi     = 3.1415926536,
+     +           root='/Volumes/mhobbins_drobo/ETrc_attribution/CONUS/')
+
+      INTEGER   mask(nrows,ncols)
+      REAL      Latdeg(nrows),Elev(nrows,ncols),avg(4,nrows,ncols),
+     +          Datavar(ncols)
+      REAL*8    sens_T(ncols),sens_R(ncols),sens_q(ncols),sens_U(ncols)
+
+
+C     Create mask to limit analysis
+      Mask = 0
+      WRITE(maskfile,'(A35,A31)') 
+     +      '/System/Volumes/Data/data/mhobbins/',
+     +      'mac159/scripts/gtopomean15k.asc'
+      OPEN(UNIT=10,FILE=maskfile,STATUS='OLD',ERR=99)
+      DO row = nrows, 1, -1
+        DO col = 1, ncols
+C         Read input data: Colin [-], column; Rowin [-], row;
+C         Lat [deg], latitude; Lon [deg], longitude; Elev [m], elevation
+          READ(10,*) Colin,Rowin,Latdeg(row),Lon,Elev(row,col)
+          IF((Rowin.NE.nrows-row+1).OR.(Colin.NE.col)) THEN
+            PRINT*,'Grid input error: colin ',Colin,'; rowin ',Rowin
+            GOTO 99
+          ENDIF
+          IF((Latdeg(row).GE.bnd_s).AND.(Latdeg(row).LE.bnd_n).AND.
+     +       (Lon.GE.bnd_w).AND.(Lon.LE.bnd_e).AND.
+     +       (Elev(row,col).GE.bnd_lo).AND.(Elev(row,col).LE.bnd_hi))
+     +       mask(row,col) = 1
+        ENDDO
+      ENDDO
+      CLOSE(10)
+
+
+      DO 60 mon = 1, 12                          ! loop through months
+
+        DO 50 day = 1, monlen(mon)               ! loop through days
+
+          PRINT*,'Month: ',mon,'; Day: ',day
+
+          avg = 0.
+
+C         Set the jday variable for the subroutine
+          jdaysub = jday(mon) + day
+          IF((mon.EQ.2).AND.(day.EQ.29)) jdaysub = 60
+
+          DO 20 var = 1, 4                       ! loop through variables
+
+C           Open variable sensitivity output files, write headers
+            WRITE(outfile,'(A47,A23,A4,A1,2I2.2,A4)')
+     +            root,'7_day_sensitivity/Sens_',
+     +            varname(var),'_',mon,day,'.asc'
+            OPEN(UNIT=10+var,FILE=outfile,STATUS='UNKNOWN')
+            WRITE(10+var,'(A6,I3)') 'ncols ',ncols
+            WRITE(10+var,'(A6,I3)') 'nrows ',nrows
+            WRITE(10+var,'(A10,I4)') 'xllcorner ',bnd_w
+            WRITE(10+var,'(A10,I2)') 'yllcorner ',bnd_s
+            WRITE(10+var,'(A14)') 'cellsize 0.125'
+            WRITE(10+var,'(A19)') 'nodata_value -9999.'
+
+C           Read climatologic input data for the day
+C             1 = T2m, daily mean T at 2 m [K]
+C             2 = SWd, downward shortwave radiation at surface [W/m2]
+C             3 = SH, specific humidity at 2 m [kg/kg]
+C             4 = U2m, wind speed at 10 m [m/sec]
+            WRITE(infile,'(A47,A12,A4,A1,2I2.2,A4)')
+     +            root,'7_day_climo/',varname(var),'_',mon,day,'.asc'
+            OPEN(UNIT=14+var,FILE=infile,STATUS='OLD')
+            DO i = 1, 6
+              READ(14+var,*)
+            ENDDO
+C           Read variable climatological means, filter for no data 
+            DO row = 1, nrows                    ! loop through rows
+              READ(14+var,*) (Datavar(col),col=1,ncols)
+              DO col = 1, ncols                  ! loop through cols
+                IF(mask(row,col).NE.0) THEN
+                  avg(var,row,col) = Datavar(col)
+                ELSE
+                  avg(var,row,col) = -9999.
+                ENDIF
+              ENDDO                              ! end col loop
+            ENDDO                                ! end row loop
+            CLOSE(14+var)
+
+20        ENDDO                                  ! end variable loop
+
+
+C         Calculate sensitivities
+
+          DO 40 row = 1, nrows                   ! loop through rows
+            sens_T = -9999.
+            sens_R = -9999.
+            sens_q = -9999.
+            sens_U = -9999.
+            DO 30 col = 1, ncols                 ! loop through cols
+              IF((mask(row,col).NE.0).AND.(avg(1,row,col).GE.0.).AND.
+     +           (avg(2,row,col).GE.0.).AND.(avg(3,row,col).GE.0.).AND.
+     +           (avg(4,row,col).GE.0.))
+     +           CALL ETrc_sensitivity(avg(1,row,col),avg(2,row,col),
+     +                  avg(3,row,col),avg(4,row,col),Elev(row,col),
+     +                  Latdeg(row)*pi/180.,jdaysub,sens_T(col),
+     +                  sens_R(col),sens_q(col),sens_U(col))
+30          ENDDO                                ! end col loop
+
+
+C           Write output surfaces to files
+
+C           Write sensitivities to output files
+            WRITE(11,*) (sens_T(col),col=1,ncols)
+            WRITE(12,*) (sens_R(col),col=1,ncols)
+            WRITE(13,*) (sens_q(col),col=1,ncols)
+            WRITE(14,*) (sens_U(col),col=1,ncols)
+40        ENDDO                                  ! end row loop
+
+C         Close output files
+          DO i = 11,14
+            CLOSE(i)
+          ENDDO
+
+50      ENDDO                                    ! end day loop
+
+60    ENDDO                                      ! end month loop
+
+99    END
+
+
+      SUBROUTINE ETrc_sensitivity(T2m,SWdn,SpHm,U2m,Elev,Lat,jday,
+     +                            sens_T,sens_R,sens_q,sens_U)
+C     ******************************************************************
+C     Estimates ETrs at the pixel in question. Inputs are scalars drawn
+C     from vectors in the main program. Output is a scalar that is
+C     inserted into a vector of ETrs in the main program.
+
+      IMPLICIT NONE
+      INTEGER  jday
+      REAL     T2m,SWdn,SpHm,U2m,Elev,Lat,Cn,Cd,alb
+      REAL*8   sens_T,sens_R,sens_q,sens_U,pi,Gsc,sigma,Rs,T,Pa,gamma,
+     +         delta,esat,w,ea,Rns,G,decl,ws,dr,Ra,Rso,RsRso,fcd,Rnl,Rn,
+     +         ETrs,A,B,C,ATa,ATb,dATadT,dATbdT,dAdT,dAdq,dAdR,dBdT,
+     +         dBdq,dBdU,dCdT,dCdU
+
+
+C     Define physical parameter constants:
+
+C     Numerator constants, Cn [mm.K.sec/(day.m.Pa)], referred to in
+C     ASCE-EWRI as units of [K.mm.sec3/(Kg.day)], which are the same.
+C= this text may not be true any more.
+      PARAMETER (Cn = 1.6)  !for tall reference crop (alfalfa) on a daily basis
+
+C     Denominator constants, Cd [sec/m], equivalent to a wind function parameter
+      PARAMETER (Cd = 0.38) !for tall reference crop (alfalfa) on a daily basis
+
+C     Pi, pi [-]
+      PARAMETER (pi = 3.1415926536)
+
+C     Albedo of reference crop, alb [-]
+      PARAMETER (alb = 0.23)
+
+C     Solar constant, Gsc [J/m2/hour]
+      PARAMETER (Gsc = 4.92e6)
+
+C     Stefan-Boltzmann constant, sigma [J/K4/m2/day]
+      PARAMETER (sigma = 4.901e-3)
+
+
+C     Downwelling SW radiation Rs [J/m2/day] = f(SWdn [W/m2])
+      Rs = SWdn * 86400.
+
+C     Daily mean temperature at 2 m, T [degC] = f(T2m [K])
+      T = T2m - 273.15
+
+C     Pressure, Pa [Pa] = f(elev [m])
+      Pa = 101300. * ((293. - 0.0065 * Elev) / 293.)**5.26
+
+C     Psychrometric constant, gamma [Pa/K] = f(Pa [Pa])
+      gamma = 0.000665 * Pa
+
+C     Slope of the saturated vapor pressure curve at T, delta [Pa/K] = f(T [degC])
+      delta = 2.503e6 * exp(17.27 * T / (T + 237.3)) / (T + 237.3)**2.
+
+C     Saturated vapor pressure, esat [Pa] = f(T [degC])
+      esat = 610.8 * exp(17.27 * T / (T + 237.3))
+
+C     Mixing ratio, w [kg/kg] = f(SpHm [kg/kg])
+      w = SpHm / (1. - SpHm)
+
+C     Actual vapor pressure, ea [Pa] = f(Patm [Pa], w [kg/kg])
+      ea = Pa * w / (0.622 + w)
+
+C     Limit ea to below or equal to esat
+      IF(ea.GT.esat) ea = esat
+
+C     Net SW radiation downward, Rns [J/m2/day] = f(alb [-], Rs [J/m2/day])
+      Rns = (1. - alb) * Rs
+
+C     Ground heat flux, G [J/m2/day], assumed to be zero at the daily time-step
+      G = 0.
+
+C     Declination, decl [rad] = f(pi [-], jday [-])
+      decl = 0.409 * sin((2. * pi * jday / 365) - 1.39)
+
+C     Sunset hour angle, ws [rad] = f(Lat [rad], decl [rad])
+      ws = acos (-1. * tan(Lat) * tan(decl))
+
+C     Inverse relative distance of earth from sun, dr [-] = f(pi [-], jday [-])
+      dr = 1. + 0.033 * cos(2. * pi * jday / 365)
+
+C     Extra-terrestrial (TOA) SW radiation, Ra [J/m2/day] = f(Gsc [J/m2/hour],
+C     dr [-], ws [rad], Lat [rad], decl [rad])
+      Ra = (24. / pi) * Gsc * dr * (ws * sin(Lat) * sin(decl)
+     +     + cos(Lat) * cos(decl) * sin(ws))
+
+C     Clear-sky SW radiation at surface, Rso [J/m2/day] = f(Ra [J/m2/day],
+C     Elev [m])
+      Rso = Ra * (0.75 + 2.e-5 * Elev)
+
+C     Relative shortwave radiation, RsRso = f(Rs [J/m2/day], Rso [J/m2/day])
+      RsRso = Rs / Rso
+      IF(RsRso.LT.0.3) RsRso = 0.3
+      IF(RsRso.GT.1.)  RsRso = 1.
+
+C     Cloudiness function, fcd [-] = f(swratio [-])
+      fcd = 1.35 * RsRso - 0.35
+      IF(fcd.LT.0.05) fcd = 0.05
+      IF(fcd.GT.1.)   fcd = 1.
+
+C     Net LW radiation upward, Rnl [J/m2/day] = f(sigma [J/K4/m2/day],
+C     fcd [-], ea [Pa], Tmx [degC], Tmn [degC])
+      Rnl = sigma * fcd * (0.34 - 0.14 * (0.001 * ea)**0.5)
+     +      * (T + 273.15)**4.
+
+C     Net radiation, Rn [J/m2/day] = f(Rns [J/m2/day], Rnl [J/m2/day])
+      Rn = Rns - Rnl
+
+C     ASCE-EWRI ETrs, ETrs [mm/day] = f(0.408e-6 [mm.m2/J], delta [Pa/K],
+C     gamma [Pa/K], u2 [m/sec], Rn [J/m2/day], G [J/m2/day], T [degC],
+C     esat [Pa], ea [Pa], Cn [K.mm.sec3/kg/day], Cd [sec/m])
+      ETrs = (0.408e-6 * delta * (Rn - G)
+     +       + gamma * (Cn / (T + 273.)) * U2m * (esat - ea))
+     +       / (delta + gamma * (1. + Cd * U2m))
+
+      A = 0.408e-6 * delta * (Rn - G)
+      B = gamma * (Cn / (T + 273.)) * U2m * (esat - ea)
+      C = delta + gamma * (1. + Cd * U2m)
+
+      ATa = 0.408e-6 * (2.503e6 * exp(17.27 * T / (T + 237.3))
+     +    / (T + 237.3)**2.) 
+      ATb = (Rns - (sigma * fcd * (0.34 - 0.14 * (0.001 * ea)**0.5)
+     +    * (T + 273.15)**4.))
+      dATadT = -(2.04245 * exp((17.27 * T) / (T + 237.3))
+     +       * (T**2. * (T + 237.3)**2. - 2049.09 *(T + 237.3)**3.
+     +       + 474.6 * T * (T + 237.3)**2. + 56311.3 * (T + 237.3)**2.))
+     +       / (T + 237.3)**7.
+      dATbdT = 0.0177088 * fcd * (-76.7982 + ea**0.5) * sigma
+     +       * (T + 273.15)**3.
+      dAdT = ATa * dATbdT + ATb * dATadT
+      dAdq = (2.41719e-9 * delta * fcd * Pa * (SpHm - 1.)
+     +     * sigma * (273.15 + T)**4.)
+     +     / ((SpHm - 1.) * ((Pa * SpHm)
+     +     / (1.6455 + SpHm))**0.5 * (1.6455 + SpHm)**2.)
+      dAdR = -0.0352512 * (alb - 1.) * delta
+     +     + (0.000210686 * delta * (-76.7982 + ea**0.5)
+     +     * sigma * (273.15 + T)**4) / Rso
+
+      B = (0.000665 * 101300. * ((293. - 0.0065 * Elev) / 293.)**5.26)
+     +  * (Cn / (T + 273.15)) * U2m
+     +  * ((610.8 * exp(17.27 * T / (T + 237.3)))
+     +  - (Pa * (SpHm / (1. - SpHm)) / (0.622 + (SpHm / (1. -SpHm)))))
+      dBdT = -1.*(67.3431 * Cn * (610.8 * exp((17.27 * T) / (237.3 + T))
+     +     - (Pa * SpHm)
+     +     / ((1 - SpHm) * (0.622 + SpHm / (1 - SpHm)))) * U2m)
+     +     / (273.15 + T)**2. + (41133.2 * Cn * exp((17.27 * T)
+     +     / (237.3 + T)) * (-(17.27 * T) / (237.3 + T)**2. + 17.27
+     +     / (237.3 + T)) * U2m) / (273.15 + T)
+      dBdq = (Cn * Pa * 293.157 * (1 - SpHm) * U2m)
+     +     / ((SpHm - 1.) * (1.6455 + SpHm)**2. * (273.15 + T))
+      dBdU = (0.000665 * Cn * Pa * (610.8 * exp((17.27 * T)/(237.3 + T))
+     +     - (Pa * w)/(0.622 + w)))/(273.15 + T)
+
+      C = 2.503e6 * exp(17.27 * T / (T + 237.3)) / (T + 237.3)**2.
+     +   + 0.000665 * Pa * (1. + Cd * U2m)
+      dCdT = -(5006000. * exp((17.27 * T)/(237.3 + T)) * (-1811.79 + T))
+     +     / (237.3 + T)**4.
+      dCdU = 0.000665 * Cd * Pa
+
+C     Compiling sensitivity components into driver sensitivities
+      sens_T = (dAdT + dBdT - (A + B) * dCdT / C) / C
+      sens_R  = dAdR / C
+      sens_q  = (dAdq + dBdq) / C
+      sens_U  = ((C * dBdU) - (A + B) * dCdU) / C**2.
+
+      RETURN
+      END

--- a/Generate_7day_climo.for
+++ b/Generate_7day_climo.for
@@ -1,0 +1,161 @@
+      PROGRAM GENERATE_7DAY_CLIMO
+C     ***************************
+C     Creates climatological, multi-year means of 7-day ETrs and 7-day drivers,
+C     for use in attribution analysis of changes in ETrs into its drivers.
+
+C     Assumes all Februarys have 29 days, using 7-day timeseries of February 29
+C     in leap years and March 1 for non-leap years.
+
+C     Input data, from NLDAS datafiles:
+C       Varin = 7-day means of driver variables and ETrs
+
+C     Output:
+C       Varout = multi-year means of 7-day driver variables and ETrs
+
+C     Author: Mike Hobbins
+C     Date: May 21, 2024
+
+      IMPLICIT  NONE
+      INTEGER   mlen(12),nrows,ncols,bnd_s,bnd_n,bnd_w,bnd_e,bnd_lo,
+     +          bnd_hi,yrstart,yrend,row,col,colin,rowin,mon,day,var,
+     +          year,i,count
+      REAL      Lat,Lon,Elev,tot
+      CHARACTER varname(5)*4,root*99,maskfile*99,tracker*17,outfile*99,
+     +          infile*99
+
+      DATA mlen/31,29,31,30,31,30,31,31,30,31,30,31/
+      DATA varname/'ETrs','T_2m','SWdn','SpHm','U_2m'/
+
+C     Define nrows and ncols, geographic bounds of analysis, and root path.
+      PARAMETER (nrows   = 224,
+     +           ncols   = 464,
+     +           bnd_s   = 25,
+     +           bnd_n   = 53,
+     +           bnd_w   = -125,
+     +           bnd_e   = -67,
+     +           bnd_lo  = -90,
+     +           bnd_hi  = 4500,
+     +           yrstart = 1980,
+     +           yrend   = 2021,
+     +           root    = '/Volumes/mhobbins_drobo/')
+
+      INTEGER Mask(nrows,ncols)
+      REAL    Varin(yrend-yrstart+1,nrows,ncols),Varout(ncols)
+
+ 
+C     Read in geographic data to set mask for analysis
+      Mask = 0
+      WRITE(maskfile,'(A35,A31)') 
+     +      '/System/Volumes/Data/data/mhobbins/',
+     +      'mac159/scripts/gtopomean15k.asc'
+      OPEN(UNIT=10,FILE=maskfile,STATUS='OLD',ERR=99)
+      DO 20 row = nrows, 1, -1
+        DO 10 col = 1, ncols
+C         - read input data: Col; Row; Lat [deg], latitude; Lon [deg],
+C         longitude; Elev [m], elevation
+          READ(10,*) colin,rowin,Lat,Lon,Elev
+          IF((rowin.NE.nrows-row+1).OR.(colin.NE.col)) THEN
+            PRINT*,'Static grid input error: col ',colin,'; row ',rowin
+            GOTO 99
+          ENDIF
+C         Generate geographic analysis mask
+          IF((Lat.GT.bnd_s).AND.(Lat.LT.bnd_n).AND.
+     +       (Lon.GT.bnd_w).AND.(Lon.LT.bnd_e).AND.
+     +       (Elev.GT.bnd_lo).AND.(Elev.LT.bnd_hi))
+     +       Mask(row,col) = 1
+10      ENDDO                                    ! end col loop
+20    ENDDO                                      ! end row loop
+      CLOSE(10)
+
+
+C     Loop through months
+      DO 90 mon = 1, 12
+
+C       Loop through days
+        DO 80 day = 1, mlen(mon)
+
+          WRITE(tracker,'(A5,I2.2,A8,I2.2)') 'Mon: ',mon,',  Day: ',day
+          PRINT*,tracker
+
+C         Loop through variables
+          DO 70 var = 1, 5
+
+C           Initialize input array
+            Varin = -9999.
+
+C           Open daily output file for climatological mean variable
+            WRITE(outfile,'(A24,A35,A4,A1,2I2.2,A4)')
+     +          root,'ETrc_attribution/CONUS/7_day_climo/',
+     +          varname(var),'_',mon,day,'.asc'
+            OPEN(UNIT=11,FILE=outfile,STATUS='UNKNOWN')
+            WRITE(11,'(A9)') 'ncols 464'
+            WRITE(11,'(A9)') 'nrows 224'
+            WRITE(11,'(A14)') 'xllcorner -125'
+            WRITE(11,'(A12)') 'yllcorner 25'
+            WRITE(11,'(A14)') 'cellsize 0.125'
+            WRITE(11,'(A19)') 'nodata_value -9999.'
+
+C           Loop through years
+            DO 30 year = yrstart, yrend
+
+C             Open daily input file for variable
+              WRITE(infile,'(A24,A32,A4,A1,I4,2I2.2,A4)')
+     +              root,'ETrc_attribution/CONUS/7_day_ts/',
+     +              varname(var),'_',year,mon,day,'.asc'
+!             use March 1 for February 29 in non-leap years
+              IF((mon.EQ.2).AND.(day.EQ.29)
+     +           .AND.(MOD(year,4).NE.0)) THEN
+                WRITE(infile,'(A24,A32,A4,A1,I4,A8)')
+     +                root,'ETrc_attribution/CONUS/7_day_ts/',
+     +                varname(var),'_',year,'0301.asc'
+              ENDIF
+              OPEN(UNIT=12,FILE=infile,STATUS='OLD',ERR=99)
+C             Read time-series grids
+              DO i = 1, 6                        ! read headers
+                READ(12,*)
+              ENDDO
+              DO row = 1, nrows                  ! read data
+                READ(12,*) (Varin(year-yrstart+1,row,col),col=1,ncols)
+              ENDDO
+              CLOSE(12)
+
+30          ENDDO                                ! end year loop
+
+
+C           Estimate daily long-term mean
+            DO 60 row = 1,nrows
+
+C             Initialise output array
+              Varout = -9999.
+
+              DO 50 col = 1,ncols
+
+                IF(Mask(row,col).EQ.1) THEN
+                  tot = 0.
+                  count = 0
+                  DO 40 year = yrstart, yrend
+                    tot = tot + Varin(year-yrstart+1,row,col)
+                    count = count + 1
+40                ENDDO
+                  Varout(col) = tot / count
+                ELSE
+                  Varout(col) = -9999.
+                ENDIF
+
+50            ENDDO                            ! end col loop
+
+C             Write output data
+              WRITE(11,*) (Varout(col),col=1,ncols)
+
+60          ENDDO                              ! end row loop
+
+C           Close output file
+            CLOSE(11)
+
+70        ENDDO                                ! end var loop
+
+80      ENDDO                                  ! end day loop
+
+90    ENDDO                                    ! end mon loop
+
+99    END

--- a/Generate_7day_ts.for
+++ b/Generate_7day_ts.for
@@ -1,0 +1,203 @@
+      PROGRAM GENERATE_7DAY_TS
+C     ************************
+C     Creates time series of 7-day running mean drivers from daily data,
+C     for use in attribution analysis of changes in ETrs into contributions
+C     from its drivers. Converts daily maximum and minimum 2-m air
+C     temperatures (Tmax and Tmin) to daily mean 2-m air temperature (T_2m),
+C     and 10-m windspeed (U10m) to 2-m windspeed (U_2m). Does not estimate 
+C     data for February 29 in non-leap years.
+
+C     Input data, from NLDAS datafiles:
+C       Varin = daily reference ET drivers
+
+C     Output:
+C       Varmean = 7-day running mean reference ET drivers
+
+C     Author: Mike Hobbins
+C     Date: May 21, 2024
+
+      IMPLICIT  NONE
+      INTEGER   mlen(12),nrows,ncols,bnd_s,bnd_n,bnd_w,bnd_e,bnd_lo,
+     +          bnd_hi,yrstart,yrend,row,col,colin,rowin,year,mon,lpdy,
+     +          day,var,winday,wday,wmon,wyear,i
+      REAL      Lat,Lon,Elev
+      CHARACTER varnamein(5)*4,varnameout(5)*4,root*99,maskfile*99,
+     +          outfile*99,inpath*99,infile*99
+      DATA mlen/31,28,31,30,31,30,31,31,30,31,30,31/
+      DATA varnamein/'ETrs','SWdn','SpHm','U10m','Tmax'/
+      DATA varnameout/'ETrs','SWdn','SpHm','U_2m','T_2m'/
+
+C     Define nrows and ncols, geographic bounds of analysis, and input
+C     and output path.
+      PARAMETER (nrows   = 224,
+     +           ncols   = 464,
+     +           bnd_s   = 25,
+     +           bnd_n   = 53,
+     +           bnd_w   = -125,
+     +           bnd_e   = -67,
+     +           bnd_lo  = -90,
+     +           bnd_hi  = 4500,
+     +           yrstart = 1980,
+     +           yrend   = 2021,
+     +           root    = '/Volumes/mhobbins_drobo/')
+
+      INTEGER Mask(nrows,ncols)
+      REAL    Varin(8,nrows,ncols),Tmin(ncols),Varmean(ncols)
+
+
+C     Read in geographic data to set mask for analysis
+      Mask = 0
+      WRITE(maskfile,'(A35,A31)') 
+     +      '/System/Volumes/Data/data/mhobbins/',
+     +      'mac159/scripts/gtopomean15k.asc'
+      OPEN(UNIT=10,FILE=maskfile,STATUS='OLD',ERR=99)
+      DO 20 row = nrows, 1, -1
+        DO 10 col = 1, ncols
+C         - read input data: Col; Row; Lat [deg], latitude; Lon [deg],
+C         longitude; Elev [m], elevation
+          READ(10,*) colin,rowin,Lat,Lon,Elev
+C         Generate geographic analysis mask
+          IF((Lat.GT.bnd_s).AND.(Lat.LT.bnd_n).AND.
+     +       (Lon.GT.bnd_w).AND.(Lon.LT.bnd_e).AND.
+     +       (Elev.GT.bnd_lo).AND.(Elev.LT.bnd_hi))
+     +       Mask(row,col) = 1
+10      ENDDO                                    ! end col loop
+20    ENDDO                                      ! end row loop
+      CLOSE(10)
+
+
+C     Loop through years
+      DO 90 year = yrstart, yrend
+
+C       Loop through months
+        DO 80 mon = 1, 12
+
+          lpdy = 0
+          IF((mon.EQ.2).AND.(MOD(year,4).EQ.0)) lpdy = 1
+
+C         Loop through days
+          DO 70 day = 1, mlen(mon) + lpdy
+
+            PRINT*,'Date:',year * 10000 + mon * 100 + day
+
+C           Initialize variable array
+            Varin = -9999.
+
+C           Loop through input and output variables
+            DO 60 var = 1, 5
+
+C             Open daily output file for weekly mean variable
+              WRITE(outfile,'(A24,A32,A4,A1,I4,2I2.2,A4)')
+     +            root,'ETrc_attribution/CONUS/7_day_ts/',
+     +            varnameout(var),'_',year,mon,day,'.asc'
+              OPEN(UNIT=13,FILE=outfile,STATUS='UNKNOWN')
+              WRITE(13,'(A9)') 'ncols 464'
+              WRITE(13,'(A9)') 'nrows 224'
+              WRITE(13,'(A14)') 'xllcorner -125'
+              WRITE(13,'(A12)') 'yllcorner 25'
+              WRITE(13,'(A14)') 'cellsize 0.125'
+              WRITE(13,'(A19)') 'nodata_value -9999.'
+
+C             Loop through days in the week window
+              DO 30 winday = -3, 3
+
+C               Determine date of start of week
+                wday  = day + winday
+                wmon  = mon
+                wyear = year
+                lpdy = 0
+                IF((wmon.EQ.2).AND.(MOD(wyear,4).EQ.0)) lpdy = 1
+                IF(wday.GT.mlen(mon)+lpdy) THEN
+                  wmon = mon + 1
+                  IF(wmon.GT.12) THEN
+                    wmon = 1
+                    wyear = year + 1
+                  ENDIF
+                  wday = wday - (mlen(mon) + lpdy)
+                ELSEIF(wday.LT.1) THEN
+                  wmon = mon - 1
+                  lpdy = 0
+                  IF((wmon.EQ.2).AND.(MOD(wyear,4).EQ.0)) lpdy = 1
+                  IF(wmon.LE.0) THEN
+                    wmon = 12
+                    wyear = wyear - 1
+                  ENDIF
+                  wday = wday + mlen(wmon) + lpdy
+                ENDIF
+
+C               Open daily input file for variable
+                inpath = 'ETrc_data/daily/'
+                WRITE(infile,'(A24,A16,A4,A1,I4,2I2.2,A4)') root,
+     +                  inpath,varnamein(var),'_',wyear,wmon,wday,'.asc'
+                IF(var.GT.1) THEN
+                  inpath = 'NLDAS_drivers/daily/'
+                  WRITE(infile,'(A24,A20,A4,A1,I4,2I2.2,A4)') root,
+     +                  inpath,varnamein(var),'_',wyear,wmon,wday,'.asc'
+                ENDIF
+                OPEN(UNIT=11,FILE=infile,STATUS='OLD',ERR=99)
+
+C               Read time-series grids
+                DO i = 1, 6                      ! read headers
+                  READ(11,*)
+                ENDDO
+                DO row = 1, nrows                ! read data
+                  READ(11,*) (Varin(winday+4,row,col),col=1,ncols)
+                ENDDO
+                CLOSE(11)
+C               Read time-series grids for Tmin to combine with Tmax for T_2m
+                IF(var.EQ.5) THEN
+                  WRITE(infile,'(A24,A20,A5,I4,2I2.2,A4)')
+     +                  root,inpath,'Tmin_',wyear,wmon,wday,'.asc'
+                  OPEN(UNIT=12,FILE=infile,STATUS='OLD',ERR=99)
+                  DO i = 1, 6                      ! read headers
+                    READ(12,*)
+                  ENDDO
+                  DO row = 1, nrows                ! read data
+                    READ(12,*) (Tmin(col),col=1,ncols)
+                    DO col = 1, ncols
+                      Varin(winday+4,row,col) = (Varin(winday+4,row,col)
+     +                                           + Tmin(col)) / 2.
+                    ENDDO
+                  ENDDO
+                  CLOSE(12)
+                ENDIF
+30            ENDDO                                ! end winday loop
+
+C             Initialise output array
+              Varmean = -9999.
+
+C             Estimate 7-day means
+              DO 50 row = 1,nrows
+
+                DO 40 col = 1,ncols
+
+                  IF(Mask(row,col).EQ.1) THEN
+                    Varmean(col) = (Varin(1,row,col) + Varin(2,row,col)
+     +                            + Varin(3,row,col) + Varin(4,row,col)
+     +                            + Varin(5,row,col) + Varin(6,row,col)
+     +                            + Varin(7,row,col)) / 7.
+                    IF(var.EQ.4) Varmean(col) = Varmean(col)
+     +                                  * 4.87 / log(67.8 * 10. - 5.42)
+                  ELSE
+                    Varmean(col) = -9999.
+                  ENDIF
+
+40              ENDDO                            ! end col loop
+
+C               Write output data
+                WRITE(13,*) (Varmean(col),col=1,ncols)
+
+50            ENDDO                              ! end row loop
+
+C             Close output file
+              CLOSE(13)
+
+60          ENDDO                                ! end var loop
+
+70        ENDDO                                  ! end day loop
+
+80      ENDDO                                    ! end mon loop
+
+90    ENDDO                                      ! end year loop
+
+99    END

--- a/Generate_T2m_U2m.for
+++ b/Generate_T2m_U2m.for
@@ -1,0 +1,112 @@
+      PROGRAM GENERATE_T2M_U2M
+C     ************************
+C     Generates daily T_2m as the average of daily Tmin and Tmax and
+C     daily U_2m as a function of daily U10m.
+
+C     Author: Mike Hobbins
+C     Date: May 21, 2024
+
+      IMPLICIT  NONE
+      INTEGER   nrows,ncols,bnd_s,bnd_n,bnd_w,bnd_e,bnd_lo,bnd_hi,row,
+     +          col,colin,rowin,i
+      REAL      Lat,Lon,Elev
+      CHARACTER root*99,specs*8,date*8,maskfile*99,outfile*99,infile*99
+
+C     Define nrows and ncols, geographic bounds of analysis, and path.
+      PARAMETER (nrows  = 224,
+     +           ncols  = 464,
+     +           bnd_s  = 25,
+     +           bnd_n  = 53,
+     +           bnd_w  = -125,
+     +           bnd_e  = -67,
+     +           bnd_lo = -90,
+     +           bnd_hi = 4500,
+     +           root  = '/Volumes/mhobbins_drobo/NLDAS_drivers/daily/')
+
+      INTEGER Mask(nrows,ncols)
+      REAL    Tmin(ncols),Tmax(ncols),U10m(ncols),T_2m(ncols),
+     +        U_2m(ncols)
+
+ 
+C     Read date from arguments
+      CALL get_command_argument(1,specs)
+      READ(specs,'(A8)') date
+
+C     Read in geographic data to set mask for analysis
+      Mask = 0
+      WRITE(maskfile,'(A35,A31)') 
+     +      '/System/Volumes/Data/data/mhobbins/',
+     +      'mac159/scripts/gtopomean15k.asc'
+      OPEN(UNIT=10,FILE=maskfile,STATUS='OLD',ERR=99)
+      DO 20 row = nrows, 1, -1
+        DO 10 col = 1, ncols
+C         - read input data: Col; Row; Lat [deg], latitude; Lon [deg],
+C         longitude; Elev [m], elevation
+          READ(10,*) colin,rowin,Lat,Lon,Elev
+          IF((rowin.NE.nrows-row+1).OR.(colin.NE.col)) THEN
+            PRINT*,'Static grid input error: col ',colin,'; row ',rowin
+            GOTO 99
+          ENDIF
+C         Generate geographic analysis mask
+          IF((Lat.GT.bnd_s).AND.(Lat.LT.bnd_n).AND.
+     +       (Lon.GT.bnd_w).AND.(Lon.LT.bnd_e).AND.
+     +       (Elev.GT.bnd_lo).AND.(Elev.LT.bnd_hi))
+     +       Mask(row,col) = 1
+10      ENDDO                                    ! end col loop
+20    ENDDO                                      ! end row loop
+      CLOSE(10)
+
+C     Open daily T_2m and U_2m output files
+      WRITE(outfile,'(A44,A5,A8,A4)') root,'T_2m_',date,'.asc'
+      OPEN(UNIT=11,FILE=outfile,STATUS='UNKNOWN')
+      WRITE(outfile,'(A44,A5,A8,A4)') root,'U_2m_',date,'.asc'
+      OPEN(UNIT=12,FILE=outfile,STATUS='UNKNOWN')
+      DO 30 i = 11,12
+        WRITE(i,'(A9)') 'ncols 464'
+        WRITE(i,'(A9)') 'nrows 224'
+        WRITE(i,'(A14)') 'xllcorner -125'
+        WRITE(i,'(A12)') 'yllcorner 25'
+        WRITE(i,'(A14)') 'cellsize 0.125'
+        WRITE(i,'(A19)') 'nodata_value -9999.'
+30    ENDDO
+
+C     Open daily Tmin, Tmax, and U10m input files
+      WRITE(infile,'(A44,A5,A8,A4)') root,'Tmin_',date,'.asc'
+      OPEN(UNIT=13,FILE=infile,STATUS='OLD',ERR=99)
+      WRITE(infile,'(A44,A5,A8,A4)') root,'Tmax_',date,'.asc'
+      OPEN(UNIT=14,FILE=infile,STATUS='OLD',ERR=99)
+      WRITE(infile,'(A44,A5,A8,A4)') root,'U10m_',date,'.asc'
+      OPEN(UNIT=15,FILE=infile,STATUS='OLD',ERR=99)
+      DO 40 i = 1, 6                      ! read headers
+        READ(13,*)
+        READ(14,*)
+        READ(15,*)
+40    ENDDO
+
+C     Read daily Tmin, Tmax, and U10m grids
+      DO 50 row = 1, nrows
+        T_2m = -9999.
+        Tmin = -9999.
+        Tmax = -9999.
+        U_2m = -9999.
+        U10m = -9999.
+        READ(13,*) (Tmin(col),col=1,ncols)
+        READ(14,*) (Tmax(col),col=1,ncols)
+        READ(15,*) (U10m(col),col=1,ncols)
+
+C       Estimate T_2m and U_2m and write to output files
+        DO col = 1, ncols
+          IF(Mask(row,col).EQ.1) THEN
+            T_2m(col) = (Tmin(col) + Tmax(col)) / 2.
+            U_2m(col) = U10m(col) * 4.87 / log(67.8 * 10. - 5.42)
+          ENDIF
+        ENDDO
+        WRITE(11,*) (T_2m(col),col=1,ncols)
+        WRITE(12,*) (U_2m(col),col=1,ncols)
+50    ENDDO
+
+      DO i = 11,15
+        CLOSE(i)
+      ENDDO
+
+99    END

--- a/Generate_T2m_U2m_history.for
+++ b/Generate_T2m_U2m_history.for
@@ -1,0 +1,134 @@
+      PROGRAM GENERATE_T2M_U2M_HISTORY
+C     ********************************
+C     Generates a multi-year timeseries of daily T_2m as the average of
+C     daily Tmin and Tmax and of daily U_2m as a function of daily U10m
+C     and sensor height.
+
+C     Author: Mike Hobbins
+C     Date: May 21, 2024
+
+      IMPLICIT  NONE
+      INTEGER   mlen(12),nrows,ncols,bnd_s,bnd_n,bnd_w,bnd_e,bnd_lo,
+     +          bnd_hi,yrstart,yrend,row,col,colin,rowin,year,mon,lpday,
+     +          day,date,i
+      REAL      Lat,Lon,Elev
+      CHARACTER root*99,maskfile*99,outfile*99,infile*99
+      DATA      mlen/31,28,31,30,31,30,31,31,30,31,30,31/
+
+C     Define nrows and ncols, geographic bounds of analysis, and path.
+      PARAMETER (nrows   = 224,
+     +           ncols   = 464,
+     +           bnd_s   = 25,
+     +           bnd_n   = 53,
+     +           bnd_w   = -125,
+     +           bnd_e   = -67,
+     +           bnd_lo  = -90,
+     +           bnd_hi  = 4500,
+     +           yrstart = 1980,
+     +           yrend   = 2021,
+     +           root  = '/Volumes/mhobbins_drobo/NLDAS_drivers/daily/')
+
+      INTEGER Mask(nrows,ncols)
+      REAL    Tmin(ncols),Tmax(ncols),T_2m(ncols),U10m(ncols),
+     +        U_2m(ncols)
+
+ 
+C     Read in geographic data to set mask for analysis
+      Mask = 0
+      WRITE(maskfile,'(A35,A31)') 
+     +      '/System/Volumes/Data/data/mhobbins/',
+     +      'mac159/scripts/gtopomean15k.asc'
+      OPEN(UNIT=10,FILE=maskfile,STATUS='OLD',ERR=99)
+      DO 20 row = nrows, 1, -1
+        DO 10 col = 1, ncols
+C         Read input data: Col; Row; Lat [deg], latitude; Lon [deg],
+C         longitude; Elev [m], elevation
+          READ(10,*) colin,rowin,Lat,Lon,Elev
+          IF((rowin.NE.nrows-row+1).OR.(colin.NE.col)) THEN
+            PRINT*,'Static grid input error: col ',colin,'; row ',rowin
+            GOTO 99
+          ENDIF
+C         Generate geographic analysis mask
+          IF((Lat.GT.bnd_s).AND.(Lat.LT.bnd_n).AND.
+     +       (Lon.GT.bnd_w).AND.(Lon.LT.bnd_e).AND.
+     +       (Elev.GT.bnd_lo).AND.(Elev.LT.bnd_hi))
+     +       Mask(row,col) = 1
+10      ENDDO                                    ! end col loop
+20    ENDDO                                      ! end row loop
+      CLOSE(10)
+
+
+C     Loop through years
+      DO 50 year = yrstart, yrend
+
+C       Loop through months
+        DO 40 mon = 1, 12
+
+          lpday = 0
+          IF((mon.EQ.2).AND.(MOD(year,4).EQ.0.)) lpday = 1
+
+C         Loop through days
+          DO 30 day = 1, mlen(mon) + lpday
+
+            date = year * 10000 + mon * 100 + day
+            PRINT*,'Date:',date
+
+C           Open daily T_2m and U_2m output files
+            WRITE(outfile,'(A44,A5,I8,A4)') root,'T_2m_',date,'.asc'
+            OPEN(UNIT=11,FILE=outfile,STATUS='UNKNOWN')
+            WRITE(outfile,'(A44,A5,I8,A4)') root,'U_2m_',date,'.asc'
+            OPEN(UNIT=12,FILE=outfile,STATUS='UNKNOWN')
+            DO i = 11,12
+              WRITE(i,'(A9)') 'ncols 464'
+              WRITE(i,'(A9)') 'nrows 224'
+              WRITE(i,'(A14)') 'xllcorner -125'
+              WRITE(i,'(A12)') 'yllcorner 25'
+              WRITE(i,'(A14)') 'cellsize 0.125'
+              WRITE(i,'(A19)') 'nodata_value -9999.'
+            ENDDO
+
+C           Open daily Tmin, Tmax, and U10m input files
+            WRITE(infile,'(A44,A5,I8,A4)') root,'Tmin_',date,'.asc'
+            OPEN(UNIT=13,FILE=infile,STATUS='OLD',ERR=99)
+            WRITE(infile,'(A44,A5,I8,A4)') root,'Tmax_',date,'.asc'
+            OPEN(UNIT=14,FILE=infile,STATUS='OLD',ERR=99)
+            WRITE(infile,'(A44,A5,I8,A4)') root,'U10m_',date,'.asc'
+            OPEN(UNIT=15,FILE=infile,STATUS='OLD',ERR=99)
+            DO i = 1, 6                          ! read headers
+              READ(13,*)
+              READ(14,*)
+              READ(15,*)
+            ENDDO
+
+C           Read daily Tmin, Tmax, and U10m grids
+            DO row = 1, nrows
+              Tmin = -9999.
+              Tmax = -9999.
+              T_2m = -9999.
+              U10m = -9999.
+              U_2m = -9999.
+              READ(13,*) (Tmin(col),col=1,ncols)
+              READ(14,*) (Tmax(col),col=1,ncols)
+              READ(15,*) (U10m(col),col=1,ncols)
+
+C             Estimate T_2m and U_2m and write to output files
+              DO col = 1, ncols
+                IF(Mask(row,col).EQ.1) THEN
+                   T_2m(col) = (Tmin(col) + Tmax(col)) / 2.
+                   U_2m(col) = U10m(col) * 4.87 / log(67.8 * 10. - 5.42)
+                ENDIF
+              ENDDO
+              WRITE(11,*) (T_2m(col),col=1,ncols)
+              WRITE(12,*) (U_2m(col),col=1,ncols)
+            ENDDO
+            DO i = 11,15
+              CLOSE(i)
+            ENDDO
+
+30        ENDDO                                  ! end day loop
+
+40      ENDDO                                    ! end mon loop
+
+50    ENDDO                                      ! end year loop
+
+99    END

--- a/Net_contribution.for
+++ b/Net_contribution.for
@@ -1,0 +1,207 @@
+      PROGRAM NET_CONTRIBUTION
+C     ************************
+C     For a series of defined intervals, estimates net contribution of
+C     each driver to the anomaly in ETrs.
+C
+C     Add cases to the "Select case" code to add extra output periods. 
+C
+C     Author: Mike Hobbins
+C     Date: May 21, 2024 
+
+      IMPLICIT  NONE
+      INTEGER   monlen(12),nrows,ncols,bnd_s,bnd_n,bnd_w,bnd_e,bnd_lo,
+     +          bnd_hi,year,mon,day,row,col,colin,rowin,daysback,date,
+     +          var,i,output,lpdy
+      REAL      Lat,Lon,Elev
+      CHARACTER varname(6)*4,root*99,specs*8,maskfile*99,infile*99,
+     +          tsname*6,outsumfile*99,outavgfile*99
+      DATA      monlen/31,28,31,30,31,30,31,31,30,31,30,31/
+      DATA      varname/'T_2m','SWdn','SpHm','U_2m','ClEr','ETrs'/
+
+C     Define nrows and ncols, and input and output paths.
+      PARAMETER (nrows  = 224,
+     +           ncols  = 464,
+     +           bnd_s  = 25,
+     +           bnd_n  = 53,
+     +           bnd_w  = -125,
+     +           bnd_e  = -67,
+     +           bnd_lo = -90,
+     +           bnd_hi = 4500,
+     +           root='/Volumes/mhobbins_drobo/ETrc_attribution/CONUS/')
+
+      INTEGER   Mask(nrows,ncols),count(nrows,ncols)
+      REAL      sumdat(6,nrows,ncols),dat(ncols),avgdat(ncols)
+
+
+C     Read in date from argument
+      CALL get_command_argument(1,specs)
+      READ(specs,'(I4,2I2)') year,mon,day
+
+C     Read in geographic data to set mask for analysis
+      Mask = 0
+      WRITE(maskfile,'(A35,A31)') 
+     +      '/System/Volumes/Data/data/mhobbins/',
+     +      'mac159/scripts/gtopomean15k.asc'
+      OPEN(UNIT=9,FILE=maskfile,STATUS='OLD',ERR=99)
+      DO 10 row = nrows, 1, -1
+        DO col = 1, ncols
+C         - read input data: Col; Row; Lat [deg], latitude; Lon [deg],
+C         longitude; Elev [m], elevation
+          READ(9,*) colin,rowin,Lat,Lon,Elev
+C         Generate geographic analysis mask
+          IF((Lat.GT.bnd_s).AND.(Lat.LT.bnd_n).AND.
+     +       (Lon.GT.bnd_w).AND.(Lon.LT.bnd_e).AND.
+     +       (Elev.GT.bnd_lo).AND.(Elev.LT.bnd_hi))
+     +       Mask(row,col) = 1
+        ENDDO                                    ! end col loop
+10    ENDDO                                      ! end row loop
+      CLOSE(9)
+
+
+C     Initialize arrays
+      count  = 0
+      sumdat = 0
+
+      DO 80 daysback = 1, 360
+
+        date = year * 10000 + mon * 100 + day
+
+        PRINT*,'Date: ',date
+
+C       Read in date's contribution file
+        DO 40 var = 1, 6
+          WRITE(infile,'(A47,A19,A4,A1,I8,A4)')
+     +          root,'contributions/Cont_',varname(var),'_',date,'.asc'
+          IF(var.EQ.6) WRITE(infile,'(A47,A24,I8,A4)')
+     +          root,'contributions/ETrs_anom_',date,'.asc'
+          OPEN(UNIT=11,FILE=infile,STATUS='OLD',ERR=99)
+
+C         Skip header of input file
+          DO i = 1, 6
+            READ(11,*)
+          ENDDO
+
+C         Loop through rows
+          DO 30 row = 1, nrows
+
+C           Read in data
+            READ(11,*) (dat(col),col=1,ncols)
+
+C           Loop through cols
+            DO 20 col = 1, ncols
+
+              IF(dat(col).NE.-9999.) THEN
+C               Add 1 to count of data
+                count(row,col) = count(row,col) + 1
+C               Add data to sum of data
+                sumdat(var,row,col) = sumdat(var,row,col) + dat(col)
+              ENDIF
+
+20          ENDDO                            ! end col loop
+
+30        ENDDO                              ! end row loop
+
+          CLOSE(11)
+
+40      ENDDO                                ! end variable loop
+
+C       Check if date is required for output
+        output = 0
+        SELECT CASE (daysback)
+          CASE (7)
+            output = 1
+            tsname = '_01wk_'
+          CASE (14)
+            output = 1
+            tsname = '_02wk_'
+          CASE (30)
+            output = 1
+            tsname = '_01mn_'
+          CASE (60)
+            output = 1
+            tsname = '_02mn_'
+          CASE (90)
+            output = 1
+            tsname = '_03mn_'
+          CASE (180)
+            output = 1
+            tsname = '_06mn_'
+          CASE (360)
+            output = 1
+            tsname = '_12mn_'
+          CASE DEFAULT
+            output = 0
+        END SELECT
+
+        IF(output.EQ.1) THEN
+
+C         Write net contribution for each variable
+          DO 70 var = 1, 6
+
+C           Open output file and write header
+            WRITE(outsumfile,'(A47,A16,A4,A6,I8,A4)') 
+     +           root,'results/Netcont_',varname(var),tsname,date,'.asc'
+            WRITE(outavgfile,'(A47,A16,A4,A6,I8,A4)') 
+     +          root,'results/Avgcont_',varname(var),tsname,date,'.asc'
+            IF(var.EQ.6) THEN
+              WRITE(outsumfile,'(A47,A23,A6,I8,A4)')
+     +             root,'results/Net_ETo_anomaly',tsname,date,'.asc'
+              WRITE(outavgfile,'(A47,A23,A6,I8,A4)')
+     +             root,'results/Avg_ETo_anomaly',tsname,date,'.asc'
+            ENDIF
+            OPEN(UNIT=12,FILE=outsumfile,STATUS='UNKNOWN')
+            OPEN(UNIT=13,FILE=outavgfile,STATUS='UNKNOWN')
+            DO i = 12, 13
+              WRITE(i,'(A9)') 'ncols 224'
+              WRITE(i,'(A9)') 'nrows 464'
+              WRITE(i,'(A14)') 'xllcorner -125'
+              WRITE(i,'(A12)') 'yllcorner 25'
+              WRITE(i,'(A14)') 'cellsize 0.125'
+              WRITE(i,'(A19)') 'NODATA_value -9999.'
+            ENDDO
+
+C           Loop through rows
+            DO 60 row = 1, nrows
+
+C             Initialize array
+              avgdat = -9999.
+
+C             Loop through cols
+              DO 50 col = 1, ncols
+
+                IF(count(row,col).GT.0)
+     +              avgdat(col) = sumdat(var,row,col) / count(row,col)
+                IF(count(row,col).LE.0)
+     +              sumdat(var,row,col) = -9999.
+
+50            ENDDO                                ! end col loop
+
+C             Write to output files
+              WRITE(12,*) (sumdat(var,row,col),col=1,ncols)
+              WRITE(13,*) (avgdat(col),col=1,ncols)
+
+60          ENDDO                                  ! end row loop
+
+            CLOSE(12)
+            CLOSE(13)
+
+70        ENDDO                                    ! end variable loop
+
+        ENDIF
+
+C       Generate date for previous day for next loop
+        day = day - 1
+        IF(day.eq.0) THEN
+          mon = mon - 1
+          IF(mon.EQ.0) THEN
+            year = year - 1
+            mon = 12
+          ENDIF
+          lpdy = 0
+          IF((mon.EQ.2).AND.(MOD(year,4).EQ.0)) lpdy = 1
+          day = monlen(mon) + lpdy
+        ENDIF
+
+80    ENDDO
+
+99    END


### PR DESCRIPTION
Fortran codes I use to run the attribution (or decomposition) of reference ET (ETrs) anomalies into contributions from its drivers.
1. Generate_7day_ts.for - Creates time series of 7-day running mean drivers from daily data, for use in attribution analysis of changes in ETrs into contributions from its drivers. Converts daily maximum and minimum 2-m air temperatures (Tmax and Tmin) to daily mean 2-m air temperature (T_2m), and 10-m windspeed (U10m) to 2-m windspeed (U_2m).
2. Generate_7day_climo.for - Creates climatological, multi-year means of 7-day ETrs and 7-day drivers, for use in attribution analysis of changes in ETrs into its drivers.
3. ETrs_sensitivity_4_drivers.for - Uses 42-year climatological means of 7-day surfaces of North American Land Data Assimilation System phase-2 (NLDAS-2) drivers to generate surfaces of daily sensitivities of ETrs (simplified relative to the strict Penman-Monteith equation recommended by the ASCE-EWRI) to each of its drivers.
4. Attribution.for - Uses data derived from NLDAS-2 to calculate the depth contribution from each of the four ETrs driving variables to daily ETrs anomalies.
5. Net_contribution.for - For a series of defined intervals, estimates net contribution of each driver to the anomaly in ETrs.

These codes might also be useful:
i) Generate_T2m_U2m_history.for - For a multi-year time series, generates daily T_2m as the average of daily Tmin and Tmax and of daily U_2m as a function of daily U10m and sensor height. ii) Generate_T2m_U2m.for - For a single day, generates daily T_2m as the average of daily Tmin and Tmax and of daily U_2m as a function of daily U10m and sensor height.